### PR TITLE
Rvinterrupt

### DIFF
--- a/src/rvinterrupt.c
+++ b/src/rvinterrupt.c
@@ -15,26 +15,35 @@ unsigned long long get_mcause()
 
 void print_mcause()
 {
-  long long mcause = get_mcause();
-
-  mcause = 0x80000000F;
+  unsigned long long mcause = get_mcause();
 
   rv_printd("Mcause: %x\n\r", mcause);
-  
+
   unsigned char interrupt = 0;
+  unsigned long long exception_code = 0;
 
   __asm__ (
       "add a0, zero, %1\n\t"
       "srli a1, a0, 0x1\n\t"
       "srai a2, a0, 0x1\n\t"
-      "beq a1, a2, end\n\t"
+      "beq a1, a2, exc\n\t"
       "addi %0, zero, 0x1\n"
 
-      "end:\n\t"
+      "exc:\n\t"
       : "+r" (interrupt)
       : "r" (mcause)
       );
 
+  __asm__(
+      "add a0, zero, %1\n\t"
+      "slli a2, a0, 0x1\n\t"
+      "srli a2, a2, 0x1\n\t"
+      "and a2, a2, a0\n\t"
+      "add %0, zero, a2\n\t"
+      : "+r" (exception_code)
+      : "r" (mcause)
+      );
+
   rv_printd("interrupt: %u\n\r", interrupt);
-  rv_printd("exception code: %u\n\r", mcause & 0x7FFFFFFFFFFFFFFF);
+  rv_printd("exception code: %u\n\r", exception_code);
 }


### PR DESCRIPTION
Сделали вывод регистра mcause независимым от длины машинного слова