### PR TITLE
создание общей функции чтения CSR регистров 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+exe/
+obj/
+.vscode/

--- a/hdr/register.h
+++ b/hdr/register.h
@@ -1,0 +1,13 @@
+#ifndef REGISTER
+#define REGISTER
+
+#define MIP "mip"
+#define MIE "mie"
+#define MCAUSE "mcause"
+#define MSTATUS "mstatus"
+
+
+#define csr_read(csr)({ register unsigned long __v; __asm__ __volatile__("csrr %0, " csr : "=r"(__v):: "memory");__v;})
+
+
+#endif

--- a/hdr/rvinterrupt.h
+++ b/hdr/rvinterrupt.h
@@ -5,6 +5,9 @@ unsigned long long get_mcause();
 void print_mcause();
 unsigned long long get_mepc();
 void print_mepc();
-
+unsigned long long get_mip();
+void print_mip();
+unsigned long long get_mie();
+void print_mie();
 #endif
 

--- a/hdr/rvinterrupt.h
+++ b/hdr/rvinterrupt.h
@@ -1,13 +1,14 @@
 #ifndef INTERRUPT
 #define INTERRUPT
 
-unsigned long long get_mcause();
+
+
 void print_mcause();
-unsigned long long get_mepc();
 void print_mepc();
-unsigned long long get_mip();
 void print_mip();
-unsigned long long get_mie();
 void print_mie();
+
+
+
 #endif
 

--- a/hdr/rvinterrupt_test.h
+++ b/hdr/rvinterrupt_test.h
@@ -5,5 +5,5 @@
 
 void mcause_test();
 void mepc_test();
-
+void mip_enable_test();
 #endif

--- a/hdr/rvminfo.h
+++ b/hdr/rvminfo.h
@@ -1,7 +1,6 @@
 #ifndef RVMINFO
 #define RVMINFO
 
-unsigned long long get_mstatus();
 void print_mstatus();
 void set_mstatus_bit();
 

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@ void test()
   
   rvminfo_test();
   mepc_test();
+  mip_enable_test();
 }
 
 int main()

--- a/src/rvinterrupt.c
+++ b/src/rvinterrupt.c
@@ -1,31 +1,10 @@
 #include "../hdr/rvinterrupt.h"
 #include "../hdr/rvio.h"
-
-unsigned long long get_mip() {
-    unsigned long long mip;
-    __asm__ __volatile__ ("csrr %0, mip" : "=r" (mip));
-    return mip;
-}
-unsigned long long get_mie() {
-    unsigned long long mie;
-    __asm__ __volatile__ ("csrr %0, mie" : "=r" (mie));
-    return mie;
-}
-unsigned long long get_mcause()
-{
-  unsigned long long mcause;
-
-  __asm__ (
-      "csrr %0, mcause\n\t"
-      : "+r" (mcause)
-      );
-
-  return mcause;
-}
+#include "../hdr/register.h"
 
 void print_mcause()
 {
-  unsigned long long mcause = get_mcause();
+  unsigned long long mcause = csr_read(MCAUSE);
 
   rv_printd("Mcause: %x\n\r", mcause);
 
@@ -71,19 +50,21 @@ void print_mepc(){
 
 void print_mip()
 {
-  unsigned long long mip = get_mip();
+  //unsigned long long mip = get_mip();
+
+  unsigned long long mip = csr_read(MIP);
   rv_printd("mip: %x\n\r", mip);
 
   rv_printd("MSIP (Machine Software Interrupt Pending): %u\n\r", (mip & (1 << 0)) != 0);
-  rv_printd("MTIP (Machine Timer Interrupt Pending): %u\n\r", (mip & (1 << 7)) != 0);
-  rv_printd("MEIP (Machine External Interrupt Pending):  %u\n\r", (mip & (1 << 11)) != 0);
+  rv_printd("MTIP (Machine Timer Interrupt Pending):    %u\n\r", (mip & (1 << 7)) != 0);
+  rv_printd("MEIP (Machine External Interrupt Pending): %u\n\r", (mip & (1 << 11)) != 0);
 }
 
 void print_mie(){
-  unsigned long long mie = get_mie();
+  unsigned long long mie = csr_read(MIE);
   rv_printd("mie: %x\n\r", mie);
 
   rv_printd("MSIE (Machine Software Interrupt Pending): %u\n\r", (mie & (1 << 3)) != 0);
-  rv_printd("MTIE (Machine Timer Interrupt Pending): %u\n\r", (mie & (1 << 7)) != 0);
-  rv_printd("MEIE (Machine External Interrupt Pending):  %u\n\r", (mie & (1 << 11)) != 0);
+  rv_printd("MTIE (Machine Timer Interrupt Pending):    %u\n\r", (mie & (1 << 7)) != 0);
+  rv_printd("MEIE (Machine External Interrupt Pending): %u\n\r", (mie & (1 << 11)) != 0);
 }

--- a/src/rvinterrupt.c
+++ b/src/rvinterrupt.c
@@ -1,6 +1,16 @@
 #include "../hdr/rvinterrupt.h"
 #include "../hdr/rvio.h"
 
+unsigned long long get_mip() {
+    unsigned long long mip;
+    __asm__ __volatile__ ("csrr %0, mepc" : "=r" (mip));
+    return mip;
+}
+unsigned long long get_mie() {
+    unsigned long long mie;
+    __asm__ __volatile__ ("csrr %0, mepc" : "=r" (mie));
+    return mie;
+}
 unsigned long long get_mcause()
 {
   unsigned long long mcause;
@@ -59,3 +69,21 @@ void print_mepc(){
   rv_printd("Mepc: %x\n\r", mepc);
 }
 
+void print_mip()
+{
+  unsigned long long mip = get_mip();
+  rv_printd("mip: %x\n\r", mip);
+
+  rv_printd("MSIP (Machine Software Interrupt Pending): %u\n\r", (mip & (1 << 0)) != 0);
+  rv_printd("MTIP (Machine Timer Interrupt Pending): %u\n\r", (mip & (1 << 7)) != 0);
+  rv_printd("MEIP (Machine External Interrupt Pending):  %u\n\r", (mip & (1 << 11)) != 0);
+}
+
+void print_mie(){
+  unsigned long long mie = get_mie();
+  rv_printd("mie: %x\n\r", mie);
+
+  rv_printd("MSIE (Machine Software Interrupt Pending): %u\n\r", (mie & (1 << 3)) != 0);
+  rv_printd("MTIE (Machine Timer Interrupt Pending): %u\n\r", (mie & (1 << 7)) != 0);
+  rv_printd("MEIE (Machine External Interrupt Pending):  %u\n\r", (mie & (1 << 11)) != 0);
+}

--- a/src/rvinterrupt.c
+++ b/src/rvinterrupt.c
@@ -3,12 +3,12 @@
 
 unsigned long long get_mip() {
     unsigned long long mip;
-    __asm__ __volatile__ ("csrr %0, mepc" : "=r" (mip));
+    __asm__ __volatile__ ("csrr %0, mip" : "=r" (mip));
     return mip;
 }
 unsigned long long get_mie() {
     unsigned long long mie;
-    __asm__ __volatile__ ("csrr %0, mepc" : "=r" (mie));
+    __asm__ __volatile__ ("csrr %0, mie" : "=r" (mie));
     return mie;
 }
 unsigned long long get_mcause()

--- a/src/rvminfo.c
+++ b/src/rvminfo.c
@@ -1,14 +1,12 @@
 #include "../hdr/rvio.h"
 #include "../hdr/rvminfo.h"
+#include "../hdr/rvinterrupt.h"
+#include "../hdr/rvinterrupt.h"
+#include "../hdr/register.h"
 
-unsigned long long get_mstatus() {
-    unsigned long long mstatus;
-    __asm__ __volatile__ ("csrr %0, mstatus" : "=r" (mstatus));
-    return mstatus;
-}
 
 void print_mstatus() {
-    unsigned long long mstatus = get_mstatus();
+    unsigned long long mstatus = csr_read(MSTATUS);
     rv_printd("Mstatus (hexademical): %x\n\r", mstatus);
 
     // Вывод расшифровки
@@ -40,7 +38,7 @@ void print_mstatus() {
 
 void set_mstatus_bit(int bit_number, int value) {
     unsigned long long mask = 1u << bit_number;
-    unsigned long long mstatus_value = get_mstatus();
+    unsigned long long mstatus_value = csr_read(MSTATUS);
     // Установка или сброс заданного бита в зависимости от значения
     if (value)
         mstatus_value |= mask;  // Установка бита

--- a/tst/rvinterrupt_test.c
+++ b/tst/rvinterrupt_test.c
@@ -9,3 +9,8 @@ void mepc_test()
 {
   print_mepc();
 }
+void mip_enable_test()
+{
+  print_mip();
+  print_mie();
+}

--- a/tst/rvminfo_test.c
+++ b/tst/rvminfo_test.c
@@ -1,15 +1,16 @@
 #include "../hdr/rvio.h"
 #include "../hdr/rvminfo.h"
 #include "../hdr/rvminfo_test.h"
+#include "../hdr/register.h"
 
 void rvminfo_test(){
   set_mstatus_bit(12,1);
   unsigned long long a;
-  a = get_mstatus();
+  a = csr_read(MSTATUS);
   rv_printd("Mstatus (binary): %b\n\r", a);
   //print_mstatus();
   set_mstatus_bit(12,0);
-  a = get_mstatus();
+  a = csr_read(MSTATUS);;
   rv_printd("Mstatus (binary): %b after changing bit\n\r", a);
   //print_mstatus(); //Закомментил принты чтоб много место не занимало
 }


### PR DESCRIPTION
1. сделал макрос который возвращает значения CSR регистра в отдельном файле /hdr/register.h, чтобы потом оперативно его подключать когда понадобиться читать регистры.
2. удалил все существующие функции чтения CSR регистров.
3. поменял все вызовы чтения регистров чтобы все существующие тесты работали.
У меня всё запускается и вроде работает также как и до замены.
Теперь чтобы добавить чтение нового регистра достаточно внести одно изменение в register.h.
Там где я это подсмотрел используется слегка другая реализация, там в директиве вместо строки с названием используют адрес, но как я понял от машины к машине адреса этих регистров могут меняться, поэтому у нас будет целесообразней юзать строку чтобы компилятор сам подставлял адреса.
